### PR TITLE
fix update value from c#

### DIFF
--- a/Projects/BlazorContentEditable/BlazorContentEditableComponent.razor
+++ b/Projects/BlazorContentEditable/BlazorContentEditableComponent.razor
@@ -4,8 +4,18 @@
 
 @code {
 
+    private string _value;
+
     [Parameter]
-    public string Value { get; set; }
+    public string Value
+    {
+        get => _value;
+        set
+        {
+            UpdateValue(value);
+            _value = value;
+        }
+    }
 
     [Parameter]
     public bool Enabled { get; set; } = true;   //default to true
@@ -82,6 +92,11 @@
         }
     }
 
+    protected async Task UpdateValue(string value)
+    {
+        await JSRuntime.InvokeAsync<string>("BlazorContentEditable", DivID, DotNetObjectReference.Create(this), value);
+    }
+    
     //receive input text from javascript and invoke callback to parent component
     [JSInvokable]
     public void GetUpdatedTextFromJavascript(string TextFromJavascript)

--- a/Projects/BlazorContentEditable/wwwroot/BlazorContentEditable.js
+++ b/Projects/BlazorContentEditable/wwwroot/BlazorContentEditable.js
@@ -15,6 +15,10 @@ function BlazorContentEditable(DivID, Instance, TextToDisplay) {
 
 }
 
+function SetValue(value) {
+    document.getElementById(DivID).innerHTML = value;
+}
+
 function SetHeight(DivID) {
 
     //reset to original height


### PR DESCRIPTION
Hello, 

this PR fix an issue I 've encountered when setting the BlazorContentEditable.Value after component initialization. 
My use case involve setting the editor value according to a combo box selection.
In this case the setted value is not reflected immediatly and need a navigation action that reload the component with the expected value.

A  reproduction cas is visible [here](https://b3b00.github.io/CslyViz/pr-preview/pr-12/) and related source is [there](https://github.com/b3b00/CslyViz/blob/feature/editors/Components/GrammarComponent.razor)

- select a value in the combo of the grammar tab
- nothing happens (expected behavior would be the text area to be filled with some content)
- navigate to the source tab than go back to grammar tab
- the value is visible in the text area

My PR propose a way to immediatly reflect the value after the combo selection.

By the way, except this little issue, your component is exactly what I was looking for so great thanks for it.

Olivier